### PR TITLE
default timeouts for long running inactive connections

### DIFF
--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -14,7 +14,11 @@ global
 defaults
     mode                    tcp
     log                     global
-
+    timeout                 client 15m 
+    timeout                 server 15m 
+    timeout                 connect 15s
+    timeout                 client-fin 30s 
+    timeout                 server-fin 30s
 #---------------------------------------------------------------------
 # round robin balancing between the LoadBalancers
 #---------------------------------------------------------------------


### PR DESCRIPTION
This is to fix https://eucalyptus.zendesk.com/agent/tickets/1458 where a number of closed connections were being held between haproxy and the destination service
