### PR TITLE
Change to how target JLB is identified

### DIFF
--- a/tasks/configure_haproxy.yml
+++ b/tasks/configure_haproxy.yml
@@ -10,14 +10,7 @@
   - elbs_ips
 
 - name: Resolve ELB DNS name A records
-  shell: dig "{{ target_dns.results[0].stdout_lines[0] }}" |
-         grep IN |
-         grep A |
-         grep -v SOA |
-         egrep '(elb|eucalyptus)' |
-         grep -v \; |
-         awk '{print $5}' |
-         sort
+  shell: dig +short "{{ target_dns.results[0].stdout_lines[0] }}"
   register: elbs_addresses
   ignore_errors: true
   tags:


### PR DESCRIPTION
John, don't merge this change yet, we're working a problem in Sydney. It seems the naming of the ELBs is sufficiently different for some stacks not to be identified by the GREP/CUT you were using. dig +short seems to be a suitable replacement but I'm making the change here so we can discuss it.